### PR TITLE
Preference feature

### DIFF
--- a/opensrp-app/AndroidManifest.xml
+++ b/opensrp-app/AndroidManifest.xml
@@ -168,6 +168,9 @@
         <activity android:name=".view.activity.NativeHomeActivity"
                   android:screenOrientation="landscape">
         </activity>
+        <activity android:name=".view.activity.SettingsActivity"
+            android:screenOrientation="landscape">
+        </activity>
 
         <receiver android:name=".view.receiver.SyncBroadcastReceiver"/>
         <receiver android:name=".view.receiver.ConnectivityChangeReceiver">

--- a/opensrp-app/res/xml/preferences.xml
+++ b/opensrp-app/res/xml/preferences.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" >
+    <PreferenceCategory android:title="Server">
+
+       <EditTextPreference 
+            android:key="DRISHTI_BASE_URL"
+            android:title="OpenSRP base URL" 
+            android:summary="Defines the base server url that handles requests"
+            android:dialogTitle="OpenSRP base URL"
+            android:dialogMessage="Enter Base Server Url"    
+            android:defaultValue="http://46.101.51.199:8080/oweb"
+            android:persistent="true"/>
+       
+       <EditTextPreference 
+            android:key="HOST"
+            android:title="Host Url" 
+            android:summary="Defines the host url of application"
+            android:dialogTitle="Host Url"
+            android:dialogMessage="Enter Host Url"    
+            android:defaultValue="http://46.101.51.199"
+            android:persistent="true"/>
+       
+       <EditTextPreference 
+            android:key="PORT"
+            android:title="Port" 
+            android:summary="Defines the port of base server url"
+            android:dialogTitle="Port"
+            android:dialogMessage="Enter port"    
+            android:defaultValue="8080"
+            android:persistent="true"/>
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/opensrp-app/src/main/java/org/ei/opensrp/Context.java
+++ b/opensrp-app/src/main/java/org/ei/opensrp/Context.java
@@ -3,6 +3,7 @@ package org.ei.opensrp;
 import android.content.res.AssetManager;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
+import android.preference.PreferenceManager;
 import android.util.Log;
 
 import org.ei.opensrp.commonregistry.AllCommonsRepository;
@@ -516,7 +517,9 @@ public class Context {
 
     public AllSharedPreferences allSharedPreferences() {
         if (allSharedPreferences == null) {
-            allSharedPreferences = new AllSharedPreferences(getDefaultSharedPreferences(this.applicationContext));
+         //   allSharedPreferences = new AllSharedPreferences(getDefaultSharedPreferences(this.applicationContext));
+            PreferenceManager.setDefaultValues(this.applicationContext, R.xml.preferences, false);
+            allSharedPreferences = new AllSharedPreferences(PreferenceManager.getDefaultSharedPreferences(this.applicationContext));
         }
         return allSharedPreferences;
     }

--- a/opensrp-app/src/main/java/org/ei/opensrp/DristhiConfiguration.java
+++ b/opensrp-app/src/main/java/org/ei/opensrp/DristhiConfiguration.java
@@ -1,6 +1,9 @@
 package org.ei.opensrp;
 
 import android.content.res.AssetManager;
+import android.util.Log;
+
+import org.ei.opensrp.repository.AllSharedPreferences;
 import org.ei.opensrp.util.IntegerUtil;
 
 import java.io.IOException;
@@ -13,10 +16,11 @@ public class DristhiConfiguration {
     private static final String PORT = "PORT";
     private static final String SHOULD_VERIFY_CERTIFICATE = "SHOULD_VERIFY_CERTIFICATE";
     private static final String SYNC_DOWNLOAD_BATCH_SIZE = "SYNC_DOWNLOAD_BATCH_SIZE";
-
+    public static AllSharedPreferences preferences;
     private Properties properties = new Properties();
 
     public DristhiConfiguration(AssetManager assetManager) {
+        preferences=Context.getInstance().allSharedPreferences();
         try {
             properties.load(assetManager.open("app.properties"));
         } catch (IOException e) {
@@ -29,11 +33,17 @@ public class DristhiConfiguration {
     }
 
     public String host() {
-        return this.get(HOST);
+
+
+        return preferences.fetchBaseURL();
+        //return preferences.fetchHost();
+                //this.get(HOST);
     }
 
     public int port() {
-        return Integer.parseInt(this.get(PORT));
+
+
+        return preferences.fetchPort();//Integer.parseInt(this.get(PORT));
     }
 
     public boolean shouldVerifyCertificate() {
@@ -41,7 +51,8 @@ public class DristhiConfiguration {
     }
 
     public String dristhiBaseURL() {
-        return this.get(DRISHTI_BASE_URL);
+
+        return preferences.fetchBaseURL();//this.get(DRISHTI_BASE_URL);
     }
 
     public int syncDownloadBatchSize() {

--- a/opensrp-app/src/main/java/org/ei/opensrp/DristhiConfiguration.java
+++ b/opensrp-app/src/main/java/org/ei/opensrp/DristhiConfiguration.java
@@ -35,15 +35,15 @@ public class DristhiConfiguration {
     public String host() {
 
 
-        return preferences.fetchBaseURL();
-        //return preferences.fetchHost();
-                //this.get(HOST);
+
+        return preferences.fetchHost();
+
     }
 
     public int port() {
 
 
-        return preferences.fetchPort();//Integer.parseInt(this.get(PORT));
+        return preferences.fetchPort();
     }
 
     public boolean shouldVerifyCertificate() {
@@ -52,7 +52,7 @@ public class DristhiConfiguration {
 
     public String dristhiBaseURL() {
 
-        return preferences.fetchBaseURL();//this.get(DRISHTI_BASE_URL);
+        return preferences.fetchBaseURL();
     }
 
     public int syncDownloadBatchSize() {

--- a/opensrp-app/src/main/java/org/ei/opensrp/repository/AllSharedPreferences.java
+++ b/opensrp-app/src/main/java/org/ei/opensrp/repository/AllSharedPreferences.java
@@ -6,7 +6,9 @@ import static org.ei.opensrp.AllConstants.*;
 
 public class AllSharedPreferences {
     public static final String ANM_IDENTIFIER_PREFERENCE_KEY = "anmIdentifier";
-
+    private static final String DRISHTI_BASE_URL = "DRISHTI_BASE_URL";
+    private static final String HOST = "HOST";
+    private static final String PORT = "PORT";
     private SharedPreferences preferences;
 
     public AllSharedPreferences(SharedPreferences preferences) {
@@ -35,5 +37,20 @@ public class AllSharedPreferences {
 
     public void saveIsSyncInProgress(Boolean isSyncInProgress) {
         preferences.edit().putBoolean(IS_SYNC_IN_PROGRESS_PREFERENCE_KEY, isSyncInProgress).commit();
+    }
+
+    public String fetchBaseURL(){
+
+      return   preferences.getString(DRISHTI_BASE_URL,"localhost");
+    }
+
+    public String fetchHost(){
+
+        return   preferences.getString(HOST,"localhost");
+    }
+
+    public Integer fetchPort(){
+
+        return  Integer.parseInt( preferences.getString(PORT,"8080"));
     }
 }

--- a/opensrp-app/src/main/java/org/ei/opensrp/service/HTTPAgent.java
+++ b/opensrp-app/src/main/java/org/ei/opensrp/service/HTTPAgent.java
@@ -127,7 +127,7 @@ public class HTTPAgent {
     }
 
     private void setCredentials(String userName, String password) {
-        httpClient.getCredentialsProvider().setCredentials(new AuthScope(configuration.host(), configuration.port(), REALM),
+        httpClient.getCredentialsProvider().setCredentials(new AuthScope(null, -1, null),
                 new UsernamePasswordCredentials(userName, password));
     }
 

--- a/opensrp-app/src/main/java/org/ei/opensrp/view/activity/SettingsActivity.java
+++ b/opensrp-app/src/main/java/org/ei/opensrp/view/activity/SettingsActivity.java
@@ -1,0 +1,26 @@
+package org.ei.opensrp.view.activity;
+
+import org.ei.opensrp.R;
+
+import android.os.Bundle;
+import android.preference.PreferenceActivity;
+import android.preference.PreferenceManager;
+import android.view.Menu;
+
+public class SettingsActivity extends PreferenceActivity{
+
+	@Override
+	protected void onCreate(Bundle savedInstanceState)
+	{
+		 super.onCreate(savedInstanceState);
+
+		 addPreferencesFromResource(R.xml.preferences); 
+	}
+	
+	@Override
+	public boolean onCreateOptionsMenu(Menu menu)
+	{
+		menu.add(Menu.NONE, 0, 0, "Show current settings");
+		return super.onCreateOptionsMenu(menu);
+	}
+}


### PR DESCRIPTION
Notes :

File : HttpAgent : line 130
Method - setCredentials 
changes : changing data from configuration.host() and REALM to null 
Reason : if host is not set to null , the app doesnt allow to user to login . show Messages"  Crenditials are wrong" 

File : AllSharedPreferences  
Method : fetchBaseURL , FetchHOST, FetchPort .
Change : adding  all these methods to class , to get data from sharedpreferences.
reason : this class is global sharedpreferences for all the app.

File : DristhiConfiguration 
Method : dristhiBaseURL(),host()  ,port() 
Change : changing return values , getting data now from sharedpreferences
reason : all connectivity data now comes from sharedpreferences

File : SettingActivity + preference.xml
Change : adding these files for preference view . 
