### PR TITLE
change access modifiers of some variables in  Secured Native Register Activity

### DIFF
--- a/opensrp-app/src/main/java/org/ei/opensrp/view/activity/SecuredNativeSmartRegisterActivity.java
+++ b/opensrp-app/src/main/java/org/ei/opensrp/view/activity/SecuredNativeSmartRegisterActivity.java
@@ -33,7 +33,7 @@ import static org.ei.opensrp.AllConstants.SHORT_DATE_FORMAT;
 
 public abstract class SecuredNativeSmartRegisterActivity extends SecuredActivity {
 
-    private static final String DIALOG_TAG = "dialog";
+    public static final String DIALOG_TAG = "dialog";
     public static final List<? extends DialogOption> DEFAULT_FILTER_OPTIONS = asList(new AllClientsFilter());
 
     private ListView clientsView;
@@ -41,16 +41,16 @@ public abstract class SecuredNativeSmartRegisterActivity extends SecuredActivity
     private TextView serviceModeView;
     private TextView appliedVillageFilterView;
     private TextView appliedSortView;
-    private EditText searchView;
-    private View searchCancelView;
+    public EditText searchView;
+    public View searchCancelView;
     private TextView titleLabelView;
 
-    private SmartRegisterPaginatedAdapter clientsAdapter;
+    public SmartRegisterPaginatedAdapter clientsAdapter;
 
-    private FilterOption currentVillageFilter;
-    private SortOption currentSortOption;
-    private FilterOption currentSearchFilter;
-    private ServiceModeOption currentServiceModeOption;
+    public FilterOption currentVillageFilter;
+    public SortOption currentSortOption;
+    public FilterOption currentSearchFilter;
+    public ServiceModeOption currentServiceModeOption;
 
     private final PaginationViewHandler paginationViewHandler = new PaginationViewHandler();
     private final NavBarActionsHandler navBarActionsHandler = new NavBarActionsHandler();


### PR DESCRIPTION
made some variables public in secured native register activity so… that they can be accessed in case of requirement of modified filter and search options. 
here are list of variables made public in Secured Native Register Activity
public static final String DIALOG_TAG
public EditText searchView;
public View searchCancelView;
 public SmartRegisterPaginatedAdapter clientsAdapter;

    public FilterOption currentVillageFilter;
    public SortOption currentSortOption;
    public FilterOption currentSearchFilter;
    public ServiceModeOption currentServiceModeOption;